### PR TITLE
feat: HUD dense 6-element statusline + loop detection (#12)

### DIFF
--- a/hooks/bestwork-hud.mjs
+++ b/hooks/bestwork-hud.mjs
@@ -375,7 +375,39 @@ const MODE_LABELS = {
   review: "review",
 };
 
-// === Render ===
+// === Git state ===
+function getGitState() {
+  try {
+    const branch = execFileSync("git", ["branch", "--show-current"], { encoding: "utf-8", timeout: 2000 }).trim();
+    if (!branch) return null;
+    const status = execFileSync("git", ["status", "--porcelain"], { encoding: "utf-8", timeout: 2000 }).trim();
+    const dirty = status.length > 0;
+    let ahead = "0";
+    try { ahead = execFileSync("git", ["rev-list", "--count", `origin/${branch}..HEAD`], { encoding: "utf-8", timeout: 2000, stdio: ["pipe", "pipe", "pipe"] }).trim(); } catch {}
+    return { branch, dirty, ahead: parseInt(ahead) || 0 };
+  } catch { return null; }
+}
+
+// === Loop detection (simple: same tool+file pattern repeated) ===
+function detectLoop() {
+  try {
+    const dataDir = join(bwDir, "data");
+    if (!existsSync(dataDir)) return false;
+    const files = readdirSync(dataDir).filter(f => f.endsWith(".jsonl")).sort().reverse();
+    if (!files.length) return false;
+    const lines = readFileSync(join(dataDir, files[0]), "utf-8").split("\n").filter(Boolean).slice(-10);
+    if (lines.length < 6) return false;
+    // Check if last 6 entries repeat a 2-step pattern (e.g. Edit→Bash→Edit→Bash→Edit→Bash)
+    const tools = lines.map(l => { try { return JSON.parse(l).toolName; } catch { return ""; } });
+    const last6 = tools.slice(-6);
+    if (last6[0] === last6[2] && last6[2] === last6[4] && last6[1] === last6[3] && last6[3] === last6[5]) {
+      return true;
+    }
+    return false;
+  } catch { return false; }
+}
+
+// === Render (6 elements: git | usage | context | session | mode | alerts) ===
 async function main() {
   const [stdinData, usage, session] = await Promise.all([
     readStdin(),
@@ -383,67 +415,71 @@ async function main() {
     Promise.resolve(getSessionInfo()),
   ]);
 
-  let out = `${B}${CC}BW${R}${D}#${VERSION}${R}`;
+  let out = `${B}${CC}BW${R}`;
 
-  // Usage: show data or -- placeholder
+  // 1. Git state
+  const git = getGitState();
+  if (git) {
+    const bc = git.dirty ? CY : CG;
+    out += ` ${bc}${git.branch}${R}`;
+    if (git.ahead > 0) out += `${D}+${git.ahead}${R}`;
+    if (git.dirty) out += `${CY}*${R}`;
+  }
+
+  // 2. Usage (5h + weekly)
   if (!usage || typeof usage !== "object") {
-    out += ` ${D}|${R} ${D}5h${R} ${D}--%${R} ${D}week${R} ${D}--%${R}`;
+    out += ` ${D}|${R} ${D}5h${R}${D}--%${R} ${D}wk${R}${D}--%${R}`;
   } else {
     const c5 = pctColor(usage.fiveHour);
-    out += ` ${D}|${R} ${D}5h${R} ${c5}${usage.fiveHour}%${R}`;
+    out += ` ${D}|${R} ${D}5h${R}${c5}${usage.fiveHour}%${R}`;
     if (usage.fiveHourReset) {
       const ms = new Date(usage.fiveHourReset).getTime() - Date.now();
       if (ms > 0) out += `${D}↻${formatDuration(ms)}${R}`;
     }
     const cw = pctColor(usage.weekly);
-    out += ` ${D}week${R} ${cw}${usage.weekly}%${R}`;
+    out += ` ${D}wk${R}${cw}${usage.weekly}%${R}`;
   }
 
-  // Context window usage
+  // 3. Context window %
   const ctx = getContextPercent(stdinData);
   if (ctx != null) {
     const cc = pctColor(ctx);
-    out += ` ${D}|${R} ${D}context${R} ${cc}${ctx}%${R}`;
+    out += ` ${D}|${R} ${D}ctx${R}${cc}${ctx}%${R}`;
   }
 
-  // Session uptime + efficiency
+  // 4. Session + efficiency
   if (session) {
-    out += ` ${D}|${R} ${D}session${R} ${CW}${session.timeStr}${R}`;
-
-    // Efficiency: avg tool calls per prompt (lower = better)
+    out += ` ${D}|${R} ${CW}${session.timeStr}${R}`;
     if (session.prompts > 0) {
       const eff = Math.round(session.calls / session.prompts);
       const ec = eff <= 10 ? CG : eff <= 20 ? CY : CR;
-      out += ` ${D}efficiency${R} ${ec}⚡${eff}${R}`;
+      out += `${ec}⚡${eff}${R}`;
     }
   }
 
-  // Active bestwork mode
+  // 5. Active mode + guards
   const gwMode = getLastGatewayAction();
   if (gwMode !== "idle") {
     const label = MODE_LABELS[gwMode] || gwMode;
-    out += ` ${D}|${R} ${D}mode${R} ${CC}${label}${R}`;
+    out += ` ${CC}${label}${R}`;
   }
+  if (existsSync(join(bwDir, "scope.lock"))) out += `${D}🔒${R}`;
+  if (existsSync(join(bwDir, "strict.lock"))) out += `${D}🛡${R}`;
 
-  // Active guards
-  if (existsSync(join(bwDir, "scope.lock"))) out += ` 🔒${D}scope${R}`;
-  if (existsSync(join(bwDir, "strict.lock"))) out += ` 🛡${D}strict${R}`;
+  // 6. Alerts (right side)
+  const cfg = existsSync(join(bwDir, "config.json")) ? (() => { try { return JSON.parse(readFileSync(join(bwDir, "config.json"), "utf-8")); } catch { return {}; } })() : {};
+  const notify = [];
+  if (cfg.notify?.discord?.webhookUrl) notify.push("📨");
+  if (cfg.notify?.slack?.webhookUrl) notify.push("📨");
+  if (notify.length > 0) out += ` ${notify.join("")}`;
 
-  // Notification channels
-  const cfg = existsSync(join(bwDir, "config.json")) ? JSON.parse(readFileSync(join(bwDir, "config.json"), "utf-8")) : {};
-  const messengers = [];
-  if (cfg.notify?.discord?.webhookUrl) messengers.push("discord");
-  if (cfg.notify?.slack?.webhookUrl) messengers.push("slack");
-  if (messengers.length > 0) out += ` ${D}msg:${messengers.join(",")}${R}`;
+  // Loop warning
+  if (detectLoop()) out += ` ${CR}${B}⚠LOOP${R}`;
 
-  // Usage alert: red warning when 5h or weekly > 90%
+  // Usage limit warning
   if (usage && typeof usage === "object") {
-    if (usage.fiveHour >= 90) {
-      out += ` ${CR}${B}⚠ 5h ${usage.fiveHour}% LIMIT${R}`;
-    }
-    if (usage.weekly >= 90) {
-      out += ` ${CR}${B}⚠ WEEK ${usage.weekly}% LIMIT${R}`;
-    }
+    if (usage.fiveHour >= 90) out += ` ${CR}${B}⚠5h${usage.fiveHour}%${R}`;
+    if (usage.weekly >= 90) out += ` ${CR}${B}⚠wk${usage.weekly}%${R}`;
   }
 
   process.stdout.write(out + "\n");

--- a/src/observe/__tests__/hud.test.ts
+++ b/src/observe/__tests__/hud.test.ts
@@ -91,7 +91,7 @@ describe("HUD basic output format", () => {
   it("should start with BW and version number", () => {
     const output = runHud();
     const plain = stripAnsi(output);
-    expect(plain).toMatch(/^BW#\d+\.\d+\.\d+/);
+    expect(plain).toMatch(/^BW /);
   });
 
   it("should contain ANSI color codes in raw output", () => {
@@ -155,13 +155,13 @@ describe("HUD usage display", () => {
     const plain = stripAnsi(output);
     // Without any cache or credentials, usage section may be absent entirely
     // or show dashes — either way it should NOT show a real percentage
-    const hasFakePercent = /\d+%\(5h\)/.test(plain);
+    const hasFakePercent = /5h\d+%/.test(plain);
     if (hasFakePercent) {
       // If there's OMC cache we can't control, that's fine — just verify format
-      expect(plain).toMatch(/\d+%\(5h\)/);
+      expect(plain).toMatch(/5h\d+%/);
     }
     // The output should still start correctly
-    expect(plain).toMatch(/^BW#/);
+    expect(plain).toMatch(/^BW /);
   });
 
   it("should show stale data when rate limited with previous success", () => {
@@ -195,7 +195,7 @@ describe("HUD usage display", () => {
     const output = runHud();
     const plain = stripAnsi(output);
     // Should contain the reset countdown (↻ followed by duration)
-    expect(plain).toMatch(/5h 80%↻\d+h?\d*m?/);
+    expect(plain).toMatch(/5h80%↻\d+h?\d*m?/);
   });
 
   it("should color-code usage based on percentage thresholds", () => {
@@ -233,18 +233,18 @@ describe("HUD session info", () => {
       expect(plain).toMatch(/\d+[smh]/);
     }
     // Always valid output regardless
-    expect(plain).toMatch(/^BW#/);
+    expect(plain).toMatch(/^BW /);
   });
 
   it("should show efficiency score when session has prompts", () => {
     const output = runHud();
     const plain = stripAnsi(output);
-    // If efficiency is displayed, it's in the format ⚡Nc/p
-    const hasEfficiency = /⚡\d+c\/p/.test(plain);
+    // If efficiency is displayed, it's in the format ⚡N
+    const hasEfficiency = /⚡\d+/.test(plain);
     if (hasEfficiency) {
-      expect(plain).toMatch(/⚡\d+c\/p/);
+      expect(plain).toMatch(/⚡\d+/);
     }
-    expect(plain).toMatch(/^BW#/);
+    expect(plain).toMatch(/^BW /);
   });
 });
 
@@ -259,7 +259,7 @@ describe("HUD context percentage", () => {
     });
     const output = runHud(input);
     const plain = stripAnsi(output);
-    expect(plain).toContain("context 25%");
+    expect(plain).toContain("ctx25%");
   });
 
   it("should show context % with tokenCount/contextWindow fallback fields", () => {
@@ -269,13 +269,13 @@ describe("HUD context percentage", () => {
     });
     const output = runHud(input);
     const plain = stripAnsi(output);
-    expect(plain).toContain("context 50%");
+    expect(plain).toContain("ctx50%");
   });
 
   it("should not show context when no token data in stdin", () => {
     const output = runHud("{}");
     const plain = stripAnsi(output);
-    expect(plain).not.toContain("context");
+    expect(plain).not.toContain("ctx");
   });
 
   it("should color context green when below 50%", () => {
@@ -316,7 +316,7 @@ describe("HUD context percentage", () => {
     const output = runHud(input);
     const plain = stripAnsi(output);
     // 33333/200000 = 16.6665 → rounds to 17%
-    expect(plain).toContain("context 17%");
+    expect(plain).toContain("ctx17%");
   });
 });
 
@@ -372,10 +372,10 @@ describe("HUD notifications", () => {
 
     const output = runHud();
     const plain = stripAnsi(output);
-    expect(plain).toContain("msg:discord");
+    expect(plain).toContain("📨");
   });
 
-  it("should show msg:slack when slack webhook configured", () => {
+  it("should show notification emoji when slack webhook configured", () => {
     const config = {
       notify: { slack: { webhookUrl: "https://hooks.slack.com/test" } },
     };
@@ -383,10 +383,10 @@ describe("HUD notifications", () => {
 
     const output = runHud();
     const plain = stripAnsi(output);
-    expect(plain).toContain("msg:slack");
+    expect(plain).toContain("📨");
   });
 
-  it("should show msg:discord,slack when both configured", () => {
+  it("should show two notification emojis when both configured", () => {
     const config = {
       notify: {
         discord: { webhookUrl: "https://discord.com/api/webhooks/test" },
@@ -397,25 +397,25 @@ describe("HUD notifications", () => {
 
     const output = runHud();
     const plain = stripAnsi(output);
-    expect(plain).toContain("msg:discord,slack");
+    expect(plain).toContain("📨📨");
   });
 
-  it("should not show msg: when no notifications configured", () => {
+  it("should not show notification emoji when no notifications configured", () => {
     const config = {};
     createTestFile(join(bwDir, "config.json"), JSON.stringify(config));
 
     const output = runHud();
     const plain = stripAnsi(output);
-    expect(plain).not.toContain("msg:");
+    expect(plain).not.toContain("📨");
   });
 
-  it("should not show msg: when notify exists but no webhook URLs", () => {
+  it("should not show notification emoji when notify exists but no webhook URLs", () => {
     const config = { notify: { discord: {}, slack: {} } };
     createTestFile(join(bwDir, "config.json"), JSON.stringify(config));
 
     const output = runHud();
     const plain = stripAnsi(output);
-    expect(plain).not.toContain("msg:");
+    expect(plain).not.toContain("📨");
   });
 });
 
@@ -509,7 +509,7 @@ describe("HUD error resilience", () => {
       timeout: 15000,
     });
     const plain = stripAnsi(output);
-    expect(plain).toMatch(/^BW#\d+\.\d+\.\d+/);
+    expect(plain).toMatch(/^BW /);
   });
 
   it("should handle empty stdin gracefully", () => {
@@ -519,7 +519,7 @@ describe("HUD error resilience", () => {
       timeout: 15000,
     });
     const plain = stripAnsi(output);
-    expect(plain).toMatch(/^BW#\d+\.\d+\.\d+/);
+    expect(plain).toMatch(/^BW /);
   });
 
   it("should handle malformed config.json gracefully", () => {
@@ -528,7 +528,7 @@ describe("HUD error resilience", () => {
     // Should not crash — the catch block falls back to fallback line
     const output = runHud();
     const plain = stripAnsi(output);
-    expect(plain).toMatch(/^BW#/);
+    expect(plain).toMatch(/^BW /);
   });
 
   it("should handle malformed gateway.log gracefully", () => {
@@ -536,7 +536,7 @@ describe("HUD error resilience", () => {
 
     const output = runHud();
     const plain = stripAnsi(output);
-    expect(plain).toMatch(/^BW#/);
+    expect(plain).toMatch(/^BW /);
     // Should not show any gateway mode
     expect(plain).not.toContain("trio");
   });


### PR DESCRIPTION
## Summary
6-element dense HUD replacing the verbose format:

```
BW main | 5h45%↻2h wk23% | ctx42% | 20m⚡10 📨
```

Elements:
1. **Git**: branch + dirty(*) + ahead(+N)
2. **5h usage** with reset countdown
3. **Weekly usage**
4. **Context window %**
5. **Session duration + efficiency**
6. **Loop detection** (⚠LOOP when Edit→Bash repeats 3x)

Alerts: `⚠5h95%` red bold when >= 90%

## Test plan
- [x] 470 tests pass, 4 skipped
- [x] Git dirty/clean display verified
- [x] 90% alert verified
- [x] Loop detection verified

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)