### PR TITLE
feat: /meetings skill + technical decisions log (#19 #23)

### DIFF
--- a/dist/smart-gateway.js
+++ b/dist/smart-gateway.js
@@ -2003,7 +2003,9 @@ var SLASH_PREFIXES = [
   "./delegate",
   "./waterfall",
   "./deliver",
-  "./blitz"
+  "./blitz",
+  // Meeting history
+  "./meetings"
 ];
 var SKILL_ROUTES = [
   {
@@ -2157,6 +2159,18 @@ var SKILL_ROUTES = [
     ],
     skill: "blitz",
     reason: "maximum parallelism blitz \u2014 all tasks at once"
+  },
+  {
+    patterns: [
+      /(?:show|list|search|find|view)\s+meetings?/i,
+      /meeting\s+(?:history|log|search|list)/i,
+      /미팅.*(목록|검색|이력|보여|찾아)/i,
+      /회의.*(기록|로그|검색|이력|목록)/i,
+      /past\s+meetings/i,
+      /ミーティング.*(履歴|一覧|検索)/i
+    ],
+    skill: "meetings",
+    reason: "meeting history search and browse"
   }
 ];
 function levenshtein(a, b) {

--- a/skills/deliver/SKILL.md
+++ b/skills/deliver/SKILL.md
@@ -94,6 +94,17 @@ Wait for user input. This is the ONLY time deliver asks for input.
 [BW] ═══════════════════════════════════
 ```
 
+After writing the meeting log footer to `.bestwork/state/meeting.jsonl`, also append a decisions entry to `.bestwork/context/decisions.md`. Create the file and directory if they do not exist.
+
+Format:
+```markdown
+## {date}: {task}
+- **Mode**: deliver ({N} targets, {K} attempts)
+- **Verdict**: {COMPLETE/INCOMPLETE}
+- **Key agents**: {comma-separated agent list}
+- **Summary**: {1-sentence summary of what was delivered}
+```
+
 ## State persistence
 
 Save deliver state to `.bestwork/state/deliver.json`:

--- a/skills/meetings/SKILL.md
+++ b/skills/meetings/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: meetings
+description: Search and browse past meeting logs
+---
+
+When this skill is invoked, you MUST follow this exact output sequence.
+
+## Step 1: Read meeting log
+
+Read `.bestwork/state/meeting.jsonl` from the project root. Each line is a JSON object. Meeting entries have a `type` field:
+
+- `type: "header"` — meeting start: `{ type: "header", date, task, mode, agents, agentCount }`
+- `type: "agent"` — agent contribution: `{ type: "agent", agent, role, output, verdict }`
+- `type: "footer"` — meeting end: `{ type: "footer", verdict, summary, rounds }`
+
+A complete meeting is a header followed by agent entries followed by a footer.
+
+If the file does not exist or is empty:
+```
+[BW] no meetings found. Run a trio/waterfall/deliver task to create meeting logs.
+```
+
+## Step 2: Determine mode
+
+Check the user's invocation:
+
+- `./meetings` (no args) — list all meetings
+- `./meetings <keyword>` — search meetings by keyword (matches task description, agent names, summary)
+- `./meetings <number>` — show full details of meeting #N
+
+## Step 3: List mode (no args)
+
+Parse all header+footer pairs and display:
+
+```
+[BW] meeting history
+
+  #1  2026-04-03 | trio | "HUD caching rewrite" | 3 agents | APPROVED
+  #2  2026-04-03 | hierarchy | "gateway accuracy test" | 4 agents | APPROVED
+  #3  2026-04-02 | squad | "4 issues parallel" | 4 agents | APPROVED
+
+  3 meetings found. Use ./meetings <keyword> to search.
+```
+
+Number meetings sequentially (#1 = oldest).
+
+## Step 4: Search mode (keyword arg)
+
+Filter meetings where the keyword appears in:
+- The task description (header `task` field)
+- Any agent name (header `agents` field)
+- The summary text (footer `summary` field)
+
+Case-insensitive matching.
+
+```
+[BW] meeting search: "auth"
+
+  #1  2026-04-03 | trio | "auth token refresh" | 3 agents | APPROVED
+  #4  2026-04-04 | squad | "OAuth integration" | 5 agents | APPROVED
+
+  2 meetings match "auth". Use ./meetings <number> for details.
+```
+
+If no matches:
+```
+[BW] no meetings match "auth". Try a different keyword.
+```
+
+## Step 5: Detail mode (number arg)
+
+Show the full meeting record:
+
+```
+[BW] meeting #2: "gateway accuracy test"
+
+  Date:    2026-04-03
+  Mode:    hierarchy (4 agents)
+  Verdict: APPROVED
+
+  Agents:
+    bestwork:tech-backend — implemented gateway rules
+    bestwork:pm-product — validated user scenarios
+    bestwork:critic-code — APPROVE, clean implementation
+    bestwork:tech-testing — 12 tests pass
+
+  Summary: Improved gateway classification with regex tightening and edge case handling.
+```
+
+If the meeting number is out of range:
+```
+[BW] meeting #99 not found. Only 3 meetings recorded.
+```
+
+## Rules
+
+- Read `.bestwork/state/meeting.jsonl` — do NOT look in `~/.bestwork/`
+- Display meetings in reverse chronological order (newest first) for list/search
+- Number meetings sequentially starting from #1 (oldest = #1)
+- Keyword search is case-insensitive and matches partial strings
+- If meeting.jsonl has malformed lines, skip them silently

--- a/skills/trio/SKILL.md
+++ b/skills/trio/SKILL.md
@@ -70,6 +70,17 @@ As each background agent completes:
 [BW] ═══════════════════════════════════
 ```
 
+After writing the meeting log footer to `.bestwork/state/meeting.jsonl`, also append a decisions entry to `.bestwork/context/decisions.md`. Create the file and directory if they do not exist.
+
+Format:
+```markdown
+## {date}: {task}
+- **Mode**: trio ({N} agents)
+- **Verdict**: {APPROVED/REJECTED}
+- **Key agents**: {comma-separated agent list}
+- **Summary**: {1-sentence summary from the meeting}
+```
+
 ## Agent allocation rules
 
 The gateway provides `taskAllocations` with agents per task. If not provided, allocate:

--- a/skills/waterfall/SKILL.md
+++ b/skills/waterfall/SKILL.md
@@ -80,6 +80,17 @@ or if gate fails:
 [BW] ═══════════════════════════════════
 ```
 
+After writing the meeting log footer to `.bestwork/state/meeting.jsonl`, also append a decisions entry to `.bestwork/context/decisions.md`. Create the file and directory if they do not exist.
+
+Format:
+```markdown
+## {date}: {task}
+- **Mode**: waterfall ({N} stages)
+- **Verdict**: {COMPLETE/HALTED at stage N}
+- **Key agents**: {comma-separated agent list}
+- **Summary**: {1-sentence summary of what was processed}
+```
+
 ## Custom waterfalls
 
 Users can define custom stage orders:

--- a/src/harness/smart-gateway.ts
+++ b/src/harness/smart-gateway.ts
@@ -35,6 +35,8 @@ const SLASH_PREFIXES = [
   "./trio", "./update",
   // New execution mode skills
   "./delegate", "./waterfall", "./deliver", "./blitz",
+  // Meeting history
+  "./meetings",
 ];
 
 // Skill keyword map — natural language to skill name
@@ -192,6 +194,18 @@ const SKILL_ROUTES: Array<{ patterns: RegExp[]; skill: string; reason: string; h
     ],
     skill: "blitz",
     reason: "maximum parallelism blitz — all tasks at once",
+  },
+  {
+    patterns: [
+      /(?:show|list|search|find|view)\s+meetings?/i,
+      /meeting\s+(?:history|log|search|list)/i,
+      /미팅.*(목록|검색|이력|보여|찾아)/i,
+      /회의.*(기록|로그|검색|이력|목록)/i,
+      /past\s+meetings/i,
+      /ミーティング.*(履歴|一覧|検索)/i,
+    ],
+    skill: "meetings",
+    reason: "meeting history search and browse",
   },
 ];
 


### PR DESCRIPTION
## Summary
- `/meetings` skill: list/search/detail past meeting decisions
- Decisions log: trio/deliver/waterfall auto-append to `.bestwork/context/decisions.md`
- Gateway routes for meetings skill (ko/en/ja)

## Test plan
- [x] 471 tests pass, 4 skipped
- [x] Gateway routes meetings skill
- [ ] `./meetings` shows meeting history
- [ ] Trio execution appends to decisions.md

Closes #19, #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)