### PR TITLE
feat: user-extensible skills (.bestwork/skills/) (#18)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .omc/
 .bestwork/
 coverage/
+.claude/worktrees/

--- a/dist/smart-gateway.js
+++ b/dist/smart-gateway.js
@@ -1960,7 +1960,7 @@ function formatConfigErrors(errors) {
 }
 
 // src/harness/smart-gateway.ts
-import { appendFileSync, mkdirSync, readFileSync, existsSync } from "fs";
+import { appendFileSync, mkdirSync, readFileSync, existsSync, readdirSync } from "fs";
 import { join as join3 } from "path";
 import { homedir as homedir2 } from "os";
 import { execSync } from "child_process";
@@ -2192,6 +2192,34 @@ function levenshtein(a, b) {
       dp[i][j] = a[i - 1] === b[j - 1] ? dp[i - 1][j - 1] : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1]);
   return dp[m][n];
 }
+function discoverUserSkills() {
+  const skills = [];
+  const dirs = [
+    join3(process.cwd(), ".bestwork", "skills"),
+    join3(homedir2(), ".bestwork", "skills")
+  ];
+  for (const dir of dirs) {
+    if (!existsSync(dir)) continue;
+    try {
+      for (const entry of readdirSync(dir)) {
+        const skillMd = join3(dir, entry, "SKILL.md");
+        if (!existsSync(skillMd)) continue;
+        try {
+          const content = readFileSync(skillMd, "utf-8");
+          const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+          if (fmMatch) {
+            const name = fmMatch[1].match(/name:\s*(.+)/)?.[1]?.trim() || entry;
+            const desc = fmMatch[1].match(/description:\s*(.+)/)?.[1]?.trim() || "";
+            skills.push({ name, description: desc, path: skillMd });
+          }
+        } catch {
+        }
+      }
+    } catch {
+    }
+  }
+  return skills;
+}
 async function readStdin() {
   return new Promise((resolve) => {
     let data = "";
@@ -2297,6 +2325,18 @@ ${formatConfigErrors(configErrors)}`);
     }
     projectConfig = merged.project;
   } catch {
+  }
+  const userSkills = discoverUserSkills();
+  for (const skill of userSkills) {
+    if (lower.includes(skill.name.toLowerCase())) {
+      output(
+        `[BW] user skill: ${skill.name}
+
+Read the SKILL.md at ${skill.path} and follow its instructions.
+Description: ${skill.description}`
+      );
+      return;
+    }
   }
   const intent = classifyIntent(prompt, projectConfig);
   const agentList = intent.suggestedAgents.join(", ");

--- a/src/harness/smart-gateway.ts
+++ b/src/harness/smart-gateway.ts
@@ -14,7 +14,7 @@ import { classifyIntent, buildExecutionPlan, formatPlan, type ExecutionMode, typ
 import { TEAM_PRESETS } from "./org.js";
 import { loadProjectConfig, loadMergedConfig, type ProjectConfig } from "./notify.js";
 import { validateConfig, formatConfigErrors } from "./config-validator.js";
-import { appendFileSync, mkdirSync, readFileSync, existsSync } from "node:fs";
+import { appendFileSync, mkdirSync, readFileSync, existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { execSync } from "node:child_process";
@@ -230,6 +230,34 @@ function levenshtein(a: string, b: string): number {
   return dp[m][n];
 }
 
+// === User-extensible skills (.bestwork/skills/ and ~/.bestwork/skills/) ===
+function discoverUserSkills(): Array<{ name: string; description: string; path: string }> {
+  const skills: Array<{ name: string; description: string; path: string }> = [];
+  const dirs = [
+    join(process.cwd(), ".bestwork", "skills"),
+    join(homedir(), ".bestwork", "skills"),
+  ];
+  for (const dir of dirs) {
+    if (!existsSync(dir)) continue;
+    try {
+      for (const entry of readdirSync(dir)) {
+        const skillMd = join(dir, entry, "SKILL.md");
+        if (!existsSync(skillMd)) continue;
+        try {
+          const content = readFileSync(skillMd, "utf-8");
+          const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+          if (fmMatch) {
+            const name = fmMatch[1].match(/name:\s*(.+)/)?.[1]?.trim() || entry;
+            const desc = fmMatch[1].match(/description:\s*(.+)/)?.[1]?.trim() || "";
+            skills.push({ name, description: desc, path: skillMd });
+          }
+        } catch {}
+      }
+    } catch {}
+  }
+  return skills;
+}
+
 function modeToTeam(mode: ExecutionMode): string | null {
   switch (mode) {
     case "trio":
@@ -351,6 +379,19 @@ async function main() {
     projectConfig = merged.project;
   } catch {
     // No config available — proceed without
+  }
+
+  // Tier 1.5: User-extensible skill routing
+  const userSkills = discoverUserSkills();
+  for (const skill of userSkills) {
+    if (lower.includes(skill.name.toLowerCase())) {
+      output(
+        `[BW] user skill: ${skill.name}\n\n` +
+        `Read the SKILL.md at ${skill.path} and follow its instructions.\n` +
+        `Description: ${skill.description}`
+      );
+      return;
+    }
   }
 
   // Tier 2: Task classification — analyze prompt and determine execution mode


### PR DESCRIPTION
## Summary
Users can add custom skills in `.bestwork/skills/` (project) and `~/.bestwork/skills/` (global).
Gateway auto-discovers SKILL.md files and routes to them.

## Changes
- `discoverUserSkills()` in smart-gateway.ts
- Tier 1.5 routing between built-in skills and classifyIntent
- Scans frontmatter for name/description

## Test plan
- [x] 1416 tests pass
- [ ] Create `.bestwork/skills/test-skill/SKILL.md` → gateway detects it

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)